### PR TITLE
Adding container lifecycle listeners.

### DIFF
--- a/project/ContainerBuild.scala
+++ b/project/ContainerBuild.scala
@@ -6,7 +6,8 @@ object ContainerBuild extends Build {
   val SCALA_VERSION = "2.11.8"
   val JDK = "1.8"
 
-  val AKKA_VERSION    = "2.4.11"
+  val AKKA_VERSION    = "2.4.16"
+  val AKKA_HTTP_VERSION = "10.0.3"
   val AKKA_SSL_VERSION = "0.2.1"
   val CONFIG_VERSION  = "1.3.0"
   val JODA_VERSION    = "2.9.4"
@@ -64,8 +65,8 @@ object ContainerBuild extends Build {
     object Compile {
       val config          = "com.typesafe"          %   "config"            % CONFIG_VERSION
       val akkaActor       = "com.typesafe.akka"     %%  "akka-actor"        % AKKA_VERSION
-      val akkaHttp        = "com.typesafe.akka"     %%  "akka-http-core"    % AKKA_VERSION
-      val akkaHttpExp     = "com.typesafe.akka"     %%  "akka-http-experimental" % AKKA_VERSION
+      val akkaHttp        = "com.typesafe.akka"     %%  "akka-http-core"    % AKKA_HTTP_VERSION
+      val akkaHttpExp     = "com.typesafe.akka"     %%  "akka-http" % AKKA_HTTP_VERSION
       val akkaSlf4j       = "com.typesafe.akka"     %%  "akka-slf4j"        % AKKA_VERSION
       val akkaRemote      = "com.typesafe.akka"     %%  "akka-remote"       % AKKA_VERSION
       val akkaSSL         = "com.typesafe"          %%  "ssl-config-akka"   % AKKA_SSL_VERSION
@@ -85,7 +86,7 @@ object ContainerBuild extends Build {
     
     object Test {
       val akkaTest        = "com.typesafe.akka"     %%  "akka-testkit"      % AKKA_VERSION  % "test"
-      val akkaHttpTest    = "com.typesafe.akka"     %%  "akka-http-testkit" % AKKA_VERSION  % "test"
+      val akkaHttpTest    = "com.typesafe.akka"     %%  "akka-http-testkit" % AKKA_HTTP_VERSION  % "test"
       val specsCore       = "org.specs2"            %%  "specs2-core"       % SPECS_VERSION % "test"
       val specsMock       = "org.specs2"            %%  "specs2-mock"       % SPECS_VERSION % "test"
       val scalazStream    = "org.scalaz.stream"     %%  "scalaz-stream"     % "0.7a"        % "test"

--- a/project/ContainerBuild.scala
+++ b/project/ContainerBuild.scala
@@ -23,7 +23,7 @@ object ContainerBuild extends Build {
   lazy val baseSettings = Seq(
     name := "Service Container",
     organization := "com.github.vonnagy",
-    version := "2.0.1.ps",
+    version := "2.0.2",
     description := "Service Container",
     scalaVersion := SCALA_VERSION,
     packageOptions in (Compile, packageBin) +=

--- a/project/ContainerBuild.scala
+++ b/project/ContainerBuild.scala
@@ -10,6 +10,7 @@ object ContainerBuild extends Build {
   val AKKA_HTTP_VERSION = "10.0.3"
   val AKKA_SSL_VERSION = "0.2.1"
   val CONFIG_VERSION  = "1.3.0"
+  val SCALA_CONFIG_VERSION  = "0.4.4"
   val JODA_VERSION    = "2.9.4"
   val JSON4S_VERSION  = "3.4.1"
   val LOGBACK_VERSION = "1.1.7"
@@ -22,7 +23,7 @@ object ContainerBuild extends Build {
   lazy val baseSettings = Seq(
     name := "Service Container",
     organization := "com.github.vonnagy",
-    version := "2.0.1",
+    version := "2.0.1.ps",
     description := "Service Container",
     scalaVersion := SCALA_VERSION,
     packageOptions in (Compile, packageBin) +=
@@ -64,6 +65,7 @@ object ContainerBuild extends Build {
 
     object Compile {
       val config          = "com.typesafe"          %   "config"            % CONFIG_VERSION
+      val scalaConfig     = "com.github.kxbmap"     %%  "configs"           % SCALA_CONFIG_VERSION
       val akkaActor       = "com.typesafe.akka"     %%  "akka-actor"        % AKKA_VERSION
       val akkaHttp        = "com.typesafe.akka"     %%  "akka-http-core"    % AKKA_HTTP_VERSION
       val akkaHttpExp     = "com.typesafe.akka"     %%  "akka-http" % AKKA_HTTP_VERSION
@@ -80,10 +82,12 @@ object ContainerBuild extends Build {
       val joda            = "joda-time"             %   "joda-time"         % JODA_VERSION
 
       val akkaKafka       = "com.sclasen"           %%  "akka-kafka"        % "0.1.0"
-      val metricsStatsd   = "com.github.jjagged"    %   "metrics-statsd"    % "1.0.0"
+      val metricsStatsd   = ("com.github.jjagged"    %   "metrics-statsd"    % "1.0.0")
+        .excludeAll(ExclusionRule(organization = "com.codahale.metrics"))
+
       val metricsDataDog  = "org.coursera"          %   "metrics-datadog"   % "1.1.3"
     }
-    
+
     object Test {
       val akkaTest        = "com.typesafe.akka"     %%  "akka-testkit"      % AKKA_VERSION  % "test"
       val akkaHttpTest    = "com.typesafe.akka"     %%  "akka-http-testkit" % AKKA_HTTP_VERSION  % "test"
@@ -100,7 +104,7 @@ object ContainerBuild extends Build {
     val logging = Seq(logback, slf4j, slf4jOverLog4j)
     val metrics = Seq(metricsCore, metricsJvm)
 
-    val base = akka ++ json ++ logging ++ metrics ++ Seq(joda)
+    val base = akka ++ json ++ logging ++ metrics ++ Seq(joda, scalaConfig)
     val test = Seq(akkaTest, akkaHttpTest, specsCore, specsMock, scalazStream)
 
     val core = base ++ test

--- a/service-container/src/main/scala/com/github/vonnagy/service/container/ContainerBuilder.scala
+++ b/service-container/src/main/scala/com/github/vonnagy/service/container/ContainerBuilder.scala
@@ -3,6 +3,7 @@ package com.github.vonnagy.service.container
 import akka.actor.Props
 import com.github.vonnagy.service.container.health.HealthCheck
 import com.github.vonnagy.service.container.http.routing.RoutedEndpoints
+import com.github.vonnagy.service.container.listener.ContainerLifecycleListener
 import com.github.vonnagy.service.container.service.ContainerService
 import com.typesafe.config.Config
 
@@ -17,6 +18,7 @@ class ContainerBuilder {
   private val routedEndpoints = ListBuffer.empty[Class[_ <: RoutedEndpoints]]
   private val healthChecks = ListBuffer.empty[HealthCheck]
   private val props = ListBuffer.empty[Tuple2[String, Props]]
+  private val listeners = ListBuffer.empty[ContainerLifecycleListener]
 
   /**
    * Add a custom config
@@ -62,6 +64,16 @@ class ContainerBuilder {
   }
 
   /**
+    * Add any lifecycle listeners that your service requires
+    * @param listener An instance of a HealthCheck
+    * @return the ContainerBuilder
+    */
+  def withListeners(listener:ContainerLifecycleListener*) = {
+    listeners ++= listener
+    this
+  }
+
+  /**
    * Construct the system
    * @return An instance of ContainerServices
    */
@@ -69,6 +81,7 @@ class ContainerBuilder {
     val svc = new ContainerService(routedEndpoints.toSeq,
       healthChecks.toSeq,
       props.toSeq,
+      listeners,
       config) with App
 
     svc

--- a/service-container/src/main/scala/com/github/vonnagy/service/container/listener/ContainerLifecycleListener.scala
+++ b/service-container/src/main/scala/com/github/vonnagy/service/container/listener/ContainerLifecycleListener.scala
@@ -1,0 +1,14 @@
+package com.github.vonnagy.service.container.listener
+
+import com.github.vonnagy.service.container.service.ContainerService
+
+/**
+  * Classes implementing this contract receive container life-cycle notification events.
+  *
+  * Created by alexsilva on 1/28/17.
+  */
+trait ContainerLifecycleListener {
+  def onShutdown(container: ContainerService)
+
+  def onStartup(container: ContainerService)
+}

--- a/service-container/src/main/scala/com/github/vonnagy/service/container/service/ContainerService.scala
+++ b/service-container/src/main/scala/com/github/vonnagy/service/container/service/ContainerService.scala
@@ -9,32 +9,35 @@ import com.github.vonnagy.service.container.http.routing.RoutedEndpoints
 import com.github.vonnagy.service.container.listener.ContainerLifecycleListener
 import com.github.vonnagy.service.container.log.LoggingAdapter
 import com.typesafe.config.Config
+import configs.syntax._
 
 import scala.concurrent.Await
 import scala.concurrent.duration._
 
 /**
- * This is the main class for the container. It takes several parameters to be used in its construction.
- * @param routeEndpoints a list of route classes to manage
- * @param healthChecks a list of health checks to register in the system
- * @param props a lost of actor props to create when starting the container
- * @param config an optional configuration to use. It will tak precedence over those pass from the command line or
- *               from the default.
- */
+  * This is the main class for the container. It takes several parameters to be used in its construction.
+  *
+  * @param routeEndpoints a list of route classes to manage
+  * @param healthChecks   a list of health checks to register in the system
+  * @param props          a lost of actor props to create when starting the container
+  * @param config         an optional configuration to use. It will tak precedence over those pass from the command line or
+  *                       from the default.
+  */
 class ContainerService(routeEndpoints: Seq[Class[_ <: RoutedEndpoints]] = Nil,
-                                 healthChecks: Seq[HealthCheck] = Nil,
-                                 props: Seq[Tuple2[String, Props]] = Nil,
-                                 val listeners: Seq[ContainerLifecycleListener] = Nil,
-                                 config: Option[Config] = None) extends CoreConfig with SystemShutdown with LoggingAdapter {
+                       healthChecks: Seq[HealthCheck] = Nil,
+                       props: Seq[Tuple2[String, Props]] = Nil,
+                       val listeners: Seq[ContainerLifecycleListener] = Nil,
+                       config: Option[Config] = None) extends CoreConfig with SystemShutdown with LoggingAdapter {
 
   // ActorSystem we will use in our application
   system = Some(ActorSystem.create("server", getConfig(config)))
   var started = false
 
+
   /**
-   * Start the service which will start the build-in Http service and
-   * instantiate all of the desired Actors, etc...
-   */
+    * Start the service which will start the build-in Http service and
+    * instantiate all of the desired Actors, etc...
+    */
   def start(): Unit = {
 
     if (!started) {
@@ -47,36 +50,39 @@ class ContainerService(routeEndpoints: Seq[Class[_ <: RoutedEndpoints]] = Nil,
       val servicesParent = system.get.actorOf(ServicesManager.props(this, routeEndpoints, props), "service")
 
       // Only block here since we are starting the system
-      implicit val timeout = Timeout(5 seconds)
-      Await.result(servicesParent ? StatusRunning, 5 seconds)
-      log.info("The container service has been started")
+      val td = getConfig(config).get[FiniteDuration]("container.startup.timeout").valueOrElse(5 seconds)
+      implicit val timeout = Timeout(td)
+      Await.result(servicesParent ? StatusRunning, td)
+      log.info("The container service has been started.")
       listeners.foreach(_.onStartup(this))
+      sys.addShutdownHook(listeners.foreach(_.onShutdown(this)))
     }
 
   }
 
   /**
-   * This will shutdown the system and wait until it has completed
-   * the shutdown process.
-   */
+    * This will shutdown the system and wait until it has completed
+    * the shutdown process.
+    */
   def shutdown(): Unit = {
     shutdownActorSystem(false) {
       // Do nothing
     }
-    listeners.foreach(_.onShutdown(this))
     started = false
   }
 
   /**
-   * Get the system's registered endpoint handlers
-   * @return a list of ``RoutedEndpoints``
-   */
+    * Get the system's registered endpoint handlers
+    *
+    * @return a list of ``RoutedEndpoints``
+    */
   def registeredRoutes(): Seq[Class[_ <: RoutedEndpoints]] = routeEndpoints
 
   /**
-   * Get the system's registered health checks
-   * @return a list of ``HealthCheck``
-   */
+    * Get the system's registered health checks
+    *
+    * @return a list of ``HealthCheck``
+    */
   def registeredHealthChecks(): Seq[HealthCheck] = if (started) Health(system.get).getChecks else healthChecks
 
 }

--- a/service-container/src/main/scala/com/github/vonnagy/service/container/service/ServicesManager.scala
+++ b/service-container/src/main/scala/com/github/vonnagy/service/container/service/ServicesManager.scala
@@ -137,8 +137,8 @@ class ServicesManager(service: ContainerService,
 
     // Create the registered services
     props.foreach { p =>
-      log.info("Starting the service {}", p._1)
-      context.actorOf(p._2, p._1)
+      val act = context.actorOf(p._2, p._1)
+      log.info(s"Starting the service ${p._1} at ${act.path}")
     }
   }
 }

--- a/service-container/src/test/scala/com/github/vonnagy/service/container/ContainerBuilderSpec.scala
+++ b/service-container/src/test/scala/com/github/vonnagy/service/container/ContainerBuilderSpec.scala
@@ -1,6 +1,7 @@
 package com.github.vonnagy.service.container
 
 import com.github.vonnagy.service.container.health.{HealthCheck, HealthInfo, HealthState}
+import com.github.vonnagy.service.container.listener.TestContainerLifecycleListener
 import org.specs2.mutable.Specification
 
 import scala.concurrent.ExecutionContext.Implicits.global
@@ -23,6 +24,19 @@ class ContainerBuilderSpec extends Specification {
       cont.shutdown
       routes.length must be equalTo 1
     }
+
+    "allow for defining listeners" in {
+
+      val cont = new ContainerBuilder()
+        .withListeners(new TestContainerLifecycleListener())
+        .build
+
+
+      val listeners = cont.listeners
+      cont.shutdown
+      listeners.length must be equalTo 1
+    }
+
 
     "allow for defining health checks" in {
 

--- a/service-container/src/test/scala/com/github/vonnagy/service/container/listener/TestContainerLifecycleListener.scala
+++ b/service-container/src/test/scala/com/github/vonnagy/service/container/listener/TestContainerLifecycleListener.scala
@@ -1,0 +1,16 @@
+package com.github.vonnagy.service.container.listener
+
+import com.github.vonnagy.service.container.service.ContainerService
+
+/**
+  * Created by alexsilva on 1/28/17.
+  */
+class TestContainerLifecycleListener extends ContainerLifecycleListener {
+  override def onShutdown(container: ContainerService): Unit = {
+    println("Listener onShutdown called.")
+  }
+
+  override def onStartup(container: ContainerService): Unit = {
+    println("Listener onStartup called.")
+  }
+}


### PR DESCRIPTION
@vonnagy I have been using your container on a separate fork and there are some changes I have been using I would like to propose.  Here is the first one:

- Allow lifecycle listeners to be added to the container definition.  The idea behind these is for custom classes (that are not actors) to be notified when the container is started/stopped and act accordingly.  The goal here is that these listeners are only called after the container has been fully started, so that listener implementations can call any of the actors registered knowing they have been loaded and will have been assigned an ActorRef.

In my specific use case, I use listeners to register Akka extensions after the container has been started.  That can only happen after the system has been initialized with all the actors.  A listener that "listens" to events seems a good way to solve this.

What you think?