### PR TITLE
Services finder

### DIFF
--- a/project/ContainerBuild.scala
+++ b/project/ContainerBuild.scala
@@ -23,7 +23,7 @@ object ContainerBuild extends Build {
   lazy val baseSettings = Seq(
     name := "Service Container",
     organization := "com.github.vonnagy",
-    version := "2.0.2",
+    version := "2.0.3",
     description := "Service Container",
     scalaVersion := SCALA_VERSION,
     packageOptions in (Compile, packageBin) +=

--- a/service-container/src/main/scala/com/github/vonnagy/service/container/http/BaseEndpoints.scala
+++ b/service-container/src/main/scala/com/github/vonnagy/service/container/http/BaseEndpoints.scala
@@ -17,7 +17,6 @@ class BaseEndpoints(implicit system: ActorSystem,
   lazy val serviceActor = system.actorSelection("akka://server/user/service")
 
   implicit val marshaller = plainMarshaller
-
   import actorRefFactory.dispatcher
 
   val route = {

--- a/service-container/src/main/scala/com/github/vonnagy/service/container/http/BaseEndpoints.scala
+++ b/service-container/src/main/scala/com/github/vonnagy/service/container/http/BaseEndpoints.scala
@@ -5,7 +5,7 @@ import akka.http.scaladsl.model.StatusCodes
 import akka.japi.Util._
 import com.github.vonnagy.service.container.http.directives.CIDRDirectives
 import com.github.vonnagy.service.container.http.routing.RoutedEndpoints
-import com.github.vonnagy.service.container.service.ShutdownService
+import com.github.vonnagy.service.container.service.ServicesManager.ShutdownService
 import org.joda.time.{DateTime, DateTimeZone}
 
 
@@ -17,6 +17,7 @@ class BaseEndpoints(implicit system: ActorSystem,
   lazy val serviceActor = system.actorSelection("akka://server/user/service")
 
   implicit val marshaller = plainMarshaller
+
   import actorRefFactory.dispatcher
 
   val route = {

--- a/service-container/src/main/scala/com/github/vonnagy/service/container/service/ContainerService.scala
+++ b/service-container/src/main/scala/com/github/vonnagy/service/container/service/ContainerService.scala
@@ -1,6 +1,6 @@
 package com.github.vonnagy.service.container.service
 
-import akka.actor.{ActorSystem, Props}
+import akka.actor.{ActorRef, ActorSystem, Props}
 import akka.pattern.ask
 import akka.util.Timeout
 import com.github.vonnagy.service.container.core.{CoreConfig, SystemShutdown}
@@ -8,11 +8,12 @@ import com.github.vonnagy.service.container.health.{Health, HealthCheck}
 import com.github.vonnagy.service.container.http.routing.RoutedEndpoints
 import com.github.vonnagy.service.container.listener.ContainerLifecycleListener
 import com.github.vonnagy.service.container.log.LoggingAdapter
+import com.github.vonnagy.service.container.service.ServicesManager.{FindService, StatusRunning}
 import com.typesafe.config.Config
 import configs.syntax._
 
-import scala.concurrent.Await
 import scala.concurrent.duration._
+import scala.concurrent.{Await, Future}
 
 /**
   * This is the main class for the container. It takes several parameters to be used in its construction.
@@ -33,6 +34,8 @@ class ContainerService(routeEndpoints: Seq[Class[_ <: RoutedEndpoints]] = Nil,
   system = Some(ActorSystem.create("server", getConfig(config)))
   var started = false
 
+  // Create the root actor that all services will run under
+  lazy val servicesParent = system.get.actorOf(ServicesManager.props(this, routeEndpoints, props), "service")
 
   /**
     * Start the service which will start the build-in Http service and
@@ -42,12 +45,8 @@ class ContainerService(routeEndpoints: Seq[Class[_ <: RoutedEndpoints]] = Nil,
 
     if (!started) {
       started = true
-
       // Update the health check registry
       healthChecks.foreach(Health(system.get).addCheck(_))
-
-      // Create the root actor that all services will run under
-      val servicesParent = system.get.actorOf(ServicesManager.props(this, routeEndpoints, props), "service")
 
       // Only block here since we are starting the system
       val td = getConfig(config).get[FiniteDuration]("container.startup.timeout").valueOrElse(5 seconds)
@@ -69,6 +68,16 @@ class ContainerService(routeEndpoints: Seq[Class[_ <: RoutedEndpoints]] = Nil,
       // Do nothing
     }
     started = false
+  }
+
+  /**
+    * Gets a registered service by its name.
+    *
+    * @return an Option containing the ActorRef of the service or None if not found.
+    */
+  def findService(name: String): Future[Option[ActorRef]] = {
+    implicit val timeout = Timeout(1 second)
+    (servicesParent ? FindService(name)).mapTo[Option[ActorRef]]
   }
 
   /**

--- a/service-container/src/main/scala/com/github/vonnagy/service/container/service/ContainerService.scala
+++ b/service-container/src/main/scala/com/github/vonnagy/service/container/service/ContainerService.scala
@@ -1,6 +1,6 @@
 package com.github.vonnagy.service.container.service
 
-import akka.actor.{ActorRef, ActorSystem, Props}
+import akka.actor.{ActorSystem, Props}
 import akka.pattern.ask
 import akka.util.Timeout
 import com.github.vonnagy.service.container.core.{CoreConfig, SystemShutdown}
@@ -8,12 +8,12 @@ import com.github.vonnagy.service.container.health.{Health, HealthCheck}
 import com.github.vonnagy.service.container.http.routing.RoutedEndpoints
 import com.github.vonnagy.service.container.listener.ContainerLifecycleListener
 import com.github.vonnagy.service.container.log.LoggingAdapter
-import com.github.vonnagy.service.container.service.ServicesManager.{FindService, StatusRunning}
+import com.github.vonnagy.service.container.service.ServicesManager.StatusRunning
 import com.typesafe.config.Config
 import configs.syntax._
 
+import scala.concurrent.Await
 import scala.concurrent.duration._
-import scala.concurrent.{Await, Future}
 
 /**
   * This is the main class for the container. It takes several parameters to be used in its construction.
@@ -68,16 +68,6 @@ class ContainerService(routeEndpoints: Seq[Class[_ <: RoutedEndpoints]] = Nil,
       // Do nothing
     }
     started = false
-  }
-
-  /**
-    * Gets a registered service by its name.
-    *
-    * @return an Option containing the ActorRef of the service or None if not found.
-    */
-  def findService(name: String): Future[Option[ActorRef]] = {
-    implicit val timeout = Timeout(1 second)
-    (servicesParent ? FindService(name)).mapTo[Option[ActorRef]]
   }
 
   /**

--- a/service-container/src/main/scala/com/github/vonnagy/service/container/service/ServicesManager.scala
+++ b/service-container/src/main/scala/com/github/vonnagy/service/container/service/ServicesManager.scala
@@ -8,6 +8,7 @@ import com.github.vonnagy.service.container.http.routing.RoutedEndpoints
 import com.github.vonnagy.service.container.http.{HttpStopped, _}
 import com.github.vonnagy.service.container.log.ActorLoggingAdapter
 import com.github.vonnagy.service.container.metrics.reporting.MetricsReportingManager
+import com.github.vonnagy.service.container.service.ServicesManager.ServiceNotFound
 
 import scala.concurrent.Future
 import scala.concurrent.duration._
@@ -19,14 +20,15 @@ object ServicesManager {
     Props(classOf[ServicesManager], service, routeEndpoints, props).withDispatcher("akka.actor.service-dispatcher")
 
   /**
-    * Looks up a service in the currently materialized ServiceManager.
+    * Looks up a service in the currently materialized ServicesManager.
     *
     * @param name The name of the service.
     * @param servicesManagerPath The service manager actor path in the system.
     *
     * The result is returned as a Future that is completed with the [[ActorRef]]
-    * if such a service exists. It is completed with failure [[ActorNotFound]] if
-    * no such actor exists or there is no service manager in the path specified.
+    * if such a service exists. It is completed with failure [[ServiceNotFound]] if
+    * no such service(actor) with that name exists
+    * or if there is no service manager in the path specified.
     */
   def findService(name: String, servicesManagerPath: String = "server/user/service")
                  (implicit system: ActorSystem): Future[ActorRef] = {

--- a/service-container/src/test/scala/com/github/vonnagy/service/container/service/ServicesManagerSpec.scala
+++ b/service-container/src/test/scala/com/github/vonnagy/service/container/service/ServicesManagerSpec.scala
@@ -59,7 +59,7 @@ class ServicesManagerSpec extends AkkaTestkitSpecs2Support(ActorSystem("test", {
       val intercept: PartialFunction[Any, Any] = {
         case m@HttpStopped =>
           act.underlyingActor.log.info(s"Intercepted HttpStopped message")
-          probe.ref ! m;
+          probe.ref ! m
           m
         case msg => msg
       }


### PR DESCRIPTION
@vonnagy This PR would give anybody using the server the ability to look up services from the container itself.  Right now, we can register services (actors) with the container, but those services are isolated from that point on.

Right now, the only way to get a reference to these services is by using ActorSelection, but that implies knowing the exact path where the service is running.

Since we are providing a name as part of the container build process, I believe there should be a way to get an actual reference to these services using this same name, so that RoutedEndpoints or Listeners can send messages directly to an ActorRef.

I added a method called findService(name:String) that returns a Future[Option[ActorRef]] that does that.

I also modified some of the mutability/side effects going on in the ContainerService class by creating a lazy val applicativ to initialize the services.

Let me know what you think!

Thanks,

-Alex