### PR TITLE
Allowing for a container name (through builder class), removing var f…

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1,4 +1,4 @@
-val CONTAINER_VERSION = "2.0.3"
+val CONTAINER_VERSION = "2.0.4"
 val SCALA_VERSION = "2.11.8"
 val JDK = "1.8"
 

--- a/service-container/src/main/scala/com/github/vonnagy/service/container/ContainerBuilder.scala
+++ b/service-container/src/main/scala/com/github/vonnagy/service/container/ContainerBuilder.scala
@@ -21,6 +21,7 @@ case class ContainerBuilder(
                              props: Seq[(String, Props)] = Seq.empty,
                              listeners: Seq[ContainerLifecycleListener] = Seq.empty,
                              config: Config = ConfigFactory.empty,
+                             name: String = "service-container",
                              system: Option[ActorSystem] = None
                            ) {
 
@@ -39,10 +40,12 @@ case class ContainerBuilder(
 
   def withActorSystem(sys: ActorSystem): ContainerBuilder = copy(system = Some(sys))
 
+  def withName(name: String): ContainerBuilder = copy(name = name)
+
   def build: ContainerService = {
-    implicit val actorSystem = system.getOrElse(ActorSystem.create("service-container", config))
+    implicit val actorSystem = system.getOrElse(ActorSystem.create(name, config))
     val svc = new ContainerService(endpoints, healthChecks, props, listeners,
-      Some(config)) with App
+      Some(config), name) with App
     svc
   }
 

--- a/service-container/src/main/scala/com/github/vonnagy/service/container/service/ServicesManager.scala
+++ b/service-container/src/main/scala/com/github/vonnagy/service/container/service/ServicesManager.scala
@@ -87,6 +87,7 @@ class ServicesManager(service: ContainerService,
     initializeServices() onComplete {
       case Success(svcs) =>
         this.services = svcs
+        log.info(s"Initialized ${services.size} services.")
         context.actorOf(HttpService.props(routeEndpoints), "http") ! HttpStart // And then Start the Http server
       case Failure(ex) =>
         //don't start
@@ -111,8 +112,6 @@ class ServicesManager(service: ContainerService,
       unstashAll()
       context.become(running)
       log.info("Http service has started")
-
-      log.info(s"Initialized ${services.size} services.")
 
     case GetHealth =>
       sender ! HealthInfo("services", HealthState.DEGRADED, s"The service is currently being initialized")

--- a/service-container/src/test/scala/com/github/vonnagy/service/container/ContainerBuilderSpec.scala
+++ b/service-container/src/test/scala/com/github/vonnagy/service/container/ContainerBuilderSpec.scala
@@ -25,6 +25,16 @@ class ContainerBuilderSpec extends Specification {
       routes.length must be equalTo 1
     }
 
+    "allow for specifying a name" in {
+
+      val cont = new ContainerBuilder()
+        .withName("Test")
+        .build
+
+      cont.shutdown
+      cont.name must be_==("Test")
+    }
+
     "allow for defining listeners" in {
 
       val cont = new ContainerBuilder()

--- a/service-container/src/test/scala/com/github/vonnagy/service/container/core/SystemShutdownSpec.scala
+++ b/service-container/src/test/scala/com/github/vonnagy/service/container/core/SystemShutdownSpec.scala
@@ -1,11 +1,12 @@
 package com.github.vonnagy.service.container.core
 
-import akka.actor.ActorSystem
+import akka.actor.{ActorSystem, Terminated}
+import org.specs2.concurrent.ExecutionEnv
 import org.specs2.mutable.Specification
 
 /**
- * Created by Ivan von Nagy on 1/19/15.
- */
+  * Created by Ivan von Nagy on 1/19/15.
+  */
 class SystemShutdownSpec extends Specification {
 
   "SystemShutdown" should {
@@ -13,12 +14,15 @@ class SystemShutdownSpec extends Specification {
     "allow the ActorSystem to be shutdown" in {
       val sys = ActorSystem()
       val shut = new SystemShutdown {
-        system = Some(sys)
+        val system = sys
       }
 
       shut.shutdownActorSystem(false) {}
-      shut.system.isEmpty must beTrue
+      implicit val ec = ExecutionEnv.fromExecutionContext(sys.dispatcher)
+      shut.system.whenTerminated must beAnInstanceOf[Terminated].await
+
       sys.whenTerminated.isCompleted must beTrue
+      success
     }
   }
 }

--- a/service-container/src/test/scala/com/github/vonnagy/service/container/service/ContainerServiceSpec.scala
+++ b/service-container/src/test/scala/com/github/vonnagy/service/container/service/ContainerServiceSpec.scala
@@ -1,11 +1,14 @@
 package com.github.vonnagy.service.container.service
 
-import org.specs2.mutable.Specification
+import akka.actor.{ActorSystem, Terminated}
+import akka.testkit.TestKit
+import org.specs2.concurrent.ExecutionEnv
+import org.specs2.mutable.SpecificationLike
 
-class ContainerServiceSpec extends Specification {
+class ContainerServiceSpec extends TestKit(ActorSystem("service-container")) with SpecificationLike {
 
   sequential
-  val cont = new ContainerService(Nil, Nil, Nil)
+  val cont = new ContainerService(Nil, Nil, Nil, name = "test")
 
   "The ContainerService" should {
 
@@ -17,9 +20,8 @@ class ContainerServiceSpec extends Specification {
 
     "shut down properly when asked" in {
       cont.shutdown
-      cont.system.isEmpty must beTrue
+      implicit val ec = ExecutionEnv.fromExecutionContext(system.dispatcher)
+      cont.system.whenTerminated must beAnInstanceOf[Terminated].await
     }
-
-
   }
 }

--- a/service-container/src/test/scala/com/github/vonnagy/service/container/service/ServicesManagerSpec.scala
+++ b/service-container/src/test/scala/com/github/vonnagy/service/container/service/ServicesManagerSpec.scala
@@ -93,7 +93,7 @@ class ServicesManagerSpec extends AkkaTestkitSpecs2Support(ActorSystem("test", {
     }
 
     "be able to send the actor a shutdown message and have it terminate the entire system" in {
-      val cont = new ContainerService(Nil, Nil, Nil)
+      val cont = new ContainerService(Nil, Nil, Nil, name = "test")
       val act = TestActorRef[ServicesManager](ServicesManager.props(cont, Nil, Nil), "service2")
 
       probe.send(act, ShutdownService)


### PR DESCRIPTION
This PR:

1. Removes the possible creation of a duplicate ActorSystem (being created both on ContainerBuilder and ContainerService) by making the ActorSystem an implicit dependency for ContainerService.  This way, users of the container can either provide an ActorSystem implicitly or allow the ContainerBuilder class to build one for them.

2. Remove the use of var/Options in the SystemShutdown trait

3. Allow users to specify a container name.  This shows up in logging and also will be the name of the ActorSystem created by default.

What do you think @vonnagy ?
